### PR TITLE
No need to validate series when parsing binary version

### DIFF
--- a/version.go
+++ b/version.go
@@ -11,7 +11,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/juju/utils/series"
 	"gopkg.in/mgo.v2/bson"
 )
 
@@ -140,8 +139,7 @@ func ParseBinary(s string) (Binary, error) {
 	}
 	b.Series = m[6]
 	b.Arch = m[7]
-	_, err := series.GetOSFromSeries(b.Series)
-	return b, err
+	return b, nil
 }
 
 // Parse parses the version, which is of the form 1.2.3


### PR DESCRIPTION
Part of fix for https://bugs.launchpad.net/juju/+bug/1637079

When parsing a binary, there's little value in attempting to validate the series. So long as it is not empty, it will be considered valid.