### PR TITLE
Rename Series to Release to make the version Binary more generic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/juju/version
+module github.com/juju/version/v2
 
 go 1.14
 

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,7 @@ github.com/juju/utils v0.0.0-20200116185830-d40c2fe10647/go.mod h1:6/KLg8Wz/y2KV
 github.com/juju/utils/v2 v2.0.0-20200923005554-4646bfea2ef1/go.mod h1:fdlDtQlzundleLLz/ggoYinEt/LmnrpNKcNTABQATNI=
 github.com/juju/version v0.0.0-20161031051906-1f41e27e54f2/go.mod h1:kE8gK5X0CImdr7qpSKl3xB2PmpySSmfj7zVbkZFs81U=
 github.com/juju/version v0.0.0-20180108022336-b64dbd566305/go.mod h1:kE8gK5X0CImdr7qpSKl3xB2PmpySSmfj7zVbkZFs81U=
+github.com/juju/version v0.0.0-20191219164919-81c1be00b9a6 h1:nrqc9b4YKpKV4lPI3GPPFbo5FUuxkWxgZE2Z8O4lgaw=
 github.com/juju/version v0.0.0-20191219164919-81c1be00b9a6/go.mod h1:kE8gK5X0CImdr7qpSKl3xB2PmpySSmfj7zVbkZFs81U=
 github.com/julienschmidt/httprouter v1.1.1-0.20151013225520-77a895ad01eb/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
@@ -63,7 +64,6 @@ gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EV
 gopkg.in/errgo.v1 v1.0.0-20161222125816-442357a80af5/go.mod h1:u0ALmqvLRxLI95fkdCEWrE6mhWYZW1aMOJHp5YXLHTg=
 gopkg.in/httprequest.v1 v1.1.1/go.mod h1:/CkavNL+g3qLOrpFHVrEx4NKepeqR4XTZWNj4sGGjz0=
 gopkg.in/mgo.v2 v2.0.0-20160818015218-f2b6f6c918c4/go.mod h1:yeKp02qBN3iKW1OzL3MGk2IdtZzaj7SFntXj72NppTA=
-gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22 h1:VpOs+IwYnYBaFnrNAeB8UUWtL3vEUnzSCL1nVjPhqrw=
 gopkg.in/mgo.v2 v2.0.0-20190816093944-a6b53ec6cb22/go.mod h1:yeKp02qBN3iKW1OzL3MGk2IdtZzaj7SFntXj72NppTA=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637/go.mod h1:BHsqpu/nsuzkT5BpiH1EMZPLyqSMM8JbIavyFACoFNk=

--- a/version.go
+++ b/version.go
@@ -30,13 +30,13 @@ var Zero = Number{}
 // Binary specifies a binary version of juju.v
 type Binary struct {
 	Number
-	Series string
-	Arch   string
+	Release string
+	Arch    string
 }
 
 // String returns the string representation of the binary version.
 func (b Binary) String() string {
-	return fmt.Sprintf("%v-%s-%s", b.Number, b.Series, b.Arch)
+	return fmt.Sprintf("%v-%s-%s", b.Number, b.Release, b.Arch)
 }
 
 // GetBSON implements bson.Getter.
@@ -107,11 +107,11 @@ const (
 	// - 1.2-alpha3.4
 	NumberRegex = `(\d{1,9})\.(\d{1,9})(?:\.|-([a-z]+))(\d{1,9})(\.\d{1,9})?`
 	// BinaryRegex for matching binary version strings in the form:
-	// - 1.2-series-arch
-	// - 1.2.3-series-arch
-	// - 1.2.3.4-series-arch
-	// - 1.2-alpha3-series-arch
-	// - 1.2-alpha3.4-series-arch
+	// - 1.2-release-arch
+	// - 1.2.3-release-arch
+	// - 1.2.3.4-release-arch
+	// - 1.2-alpha3-release-arch
+	// - 1.2-alpha3.4-release-arch
 	BinaryRegex = NumberRegex + `-([^-]+)-([^-]+)`
 )
 
@@ -154,7 +154,7 @@ func ParseBinary(s string) (Binary, error) {
 	if m[5] != "" {
 		b.Build = atoi(m[5][1:])
 	}
-	b.Series = m[6]
+	b.Release = m[6]
 	b.Arch = m[7]
 	return b, nil
 }

--- a/version_test.go
+++ b/version_test.go
@@ -12,7 +12,7 @@ import (
 	gc "gopkg.in/check.v1"
 	goyaml "gopkg.in/yaml.v2"
 
-	"github.com/juju/version"
+	"github.com/juju/version/v2"
 )
 
 type suite struct{}
@@ -202,8 +202,8 @@ func binaryVersion(major, minor, patch, build int, tag, series, arch string) ver
 			Build: build,
 			Tag:   tag,
 		},
-		Series: series,
-		Arch:   arch,
+		Release: series,
+		Arch:    arch,
 	}
 }
 
@@ -213,10 +213,10 @@ func (*suite) TestParseBinary(c *gc.C) {
 		err    string
 		expect version.Binary
 	}{{
-		v:      "1.2.3-trusty-amd64",
-		expect: binaryVersion(1, 2, 3, 0, "", "trusty", "amd64"),
+		v:      "1.2.3-ubuntu-amd64",
+		expect: binaryVersion(1, 2, 3, 0, "", "ubuntu", "amd64"),
 	}, {
-		v: "1.2-tag3-bionic-amd64",
+		v: "1.2-tag3-windows-amd64",
 		expect: version.Binary{
 			Number: version.Number{
 				Major: 1,
@@ -225,18 +225,18 @@ func (*suite) TestParseBinary(c *gc.C) {
 				Build: 4,
 				Tag:   "tag",
 			}.ToPatch(),
-			Series: "bionic",
-			Arch:   "amd64",
+			Release: "windows",
+			Arch:    "amd64",
 		},
 	}, {
-		v:      "1.2.3.4-trusty-amd64",
-		expect: binaryVersion(1, 2, 3, 4, "", "trusty", "amd64"),
+		v:      "1.2.3.4-ubuntu-amd64",
+		expect: binaryVersion(1, 2, 3, 4, "", "ubuntu", "amd64"),
 	}, {
-		v:      "1.2-alpha3-trusty-amd64",
-		expect: binaryVersion(1, 2, 3, 0, "alpha", "trusty", "amd64"),
+		v:      "1.2-alpha3-ubuntu-amd64",
+		expect: binaryVersion(1, 2, 3, 0, "alpha", "ubuntu", "amd64"),
 	}, {
-		v:      "1.2-alpha3.4-trusty-amd64",
-		expect: binaryVersion(1, 2, 3, 4, "alpha", "trusty", "amd64"),
+		v:      "1.2-alpha3.4-ubuntu-amd64",
+		expect: binaryVersion(1, 2, 3, 4, "alpha", "ubuntu", "amd64"),
 	}, {
 		v:   "1.2.3",
 		err: "invalid binary version.*",
@@ -247,7 +247,7 @@ func (*suite) TestParseBinary(c *gc.C) {
 		v:   "1.2.3--amd64",
 		err: "invalid binary version.*",
 	}, {
-		v:   "1.2.3-trusty-",
+		v:   "1.2.3-ubuntu-",
 		err: "invalid binary version.*",
 	}}
 
@@ -264,12 +264,12 @@ func (*suite) TestParseBinary(c *gc.C) {
 
 	for i, test := range parseTests {
 		c.Logf("second test, %d: %q", i, test.v)
-		v := test.v + "-trusty-amd64"
+		v := test.v + "-ubuntu-amd64"
 		got, err := version.ParseBinary(v)
 		expect := version.Binary{
-			Number: test.expect,
-			Series: "trusty",
-			Arch:   "amd64",
+			Number:  test.expect,
+			Release: "ubuntu",
+			Arch:    "amd64",
 		}
 		if test.err != "" {
 			c.Assert(err, gc.ErrorMatches, strings.Replace(test.err, "version", "binary version", 1))
@@ -306,7 +306,7 @@ func (*suite) TestBinaryMarshalUnmarshal(c *gc.C) {
 		}
 		// Work around goyaml bug #1096149
 		// SetYAML is not called for non-pointer fields.
-		bp := version.MustParseBinary("1.2.3-trusty-amd64")
+		bp := version.MustParseBinary("1.2.3-ubuntu-amd64")
 		v := doc{&bp}
 		data, err := m.marshal(&v)
 		c.Assert(err, jc.ErrorIsNil)


### PR DESCRIPTION
Rename Series to Release to make the version Binary more generic.

Juju will start publishing agent binaries based on OS type, eg "ubuntu" so Series isn't really applicable.
Simplestreams uses "release" generically so this aligns with that terminology.
