### PR TITLE
Support non-strict version parsing

### DIFF
--- a/version_test.go
+++ b/version_test.go
@@ -193,6 +193,40 @@ func (*suite) TestParse(c *gc.C) {
 	}
 }
 
+var parseNonStrictTests = []struct {
+	v      string
+	err    string
+	expect string
+}{{
+	v:      "1",
+	expect: "1.0.0",
+}, {
+	v:      "1.2",
+	expect: "1.2.0",
+}, {
+	v:      "1.2-alpha",
+	expect: "1.2-alpha0",
+}, {
+	v:   "1.",
+	err: "invalid version.*",
+}, {
+	v:   "1.2-",
+	err: "invalid version.*",
+}}
+
+func (*suite) TestParseNonStrict(c *gc.C) {
+	for i, test := range parseNonStrictTests {
+		c.Logf("test %d: %q", i, test.v)
+		got, err := version.ParseNonStrict(test.v)
+		if test.err != "" {
+			c.Assert(err, gc.ErrorMatches, test.err)
+		} else {
+			c.Assert(err, jc.ErrorIsNil)
+			c.Check(got.String(), gc.Equals, test.expect)
+		}
+	}
+}
+
 func binaryVersion(major, minor, patch, build int, tag, series, arch string) version.Binary {
 	return version.Binary{
 		Number: version.Number{


### PR DESCRIPTION
This PR introduces a `ParseNonStrict` helper function which is the non-strict equivalent of `Parse`. It can parse the same patterns as `Parse` with the addition of : `major`, `major.minor` and `major.minor-patch` version values.

The implementation updates the regex used for matching version numbers to use optional named capture groups and the actual parsing has been extracted to a helper function that receives a map with the matched groups and a flag that indicates whether we are parsing in strict mode or not.

The new helper function is meant to be used by the charm code to parse _semver-like_ constraints within an `assumes` block.

------

The updated regex can be visualized like so:

![image](https://user-images.githubusercontent.com/616049/136225956-29860114-835e-4587-898c-8c76cfd902bd.png)
